### PR TITLE
Switch to uv packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@ A modular Flask application that generates PowerPoint decks from a text prompt a
 ## Quickstart
 
 ```bash
-pip install -r requirements.txt
+# Install the fast `uv` package manager
+pip install uv
+
+# Create a virtual environment and install dependencies
+uv venv
+uv pip install -e .[dev]
+
+# Run the development server
 cp .env.example .env  # populate environment variables locally
 python -m flask --app app:create_app run
 ```

--- a/app/slide_generator.py
+++ b/app/slide_generator.py
@@ -1,13 +1,13 @@
 import json
 from typing import Dict, Any, List
 
-import openai
-
 from .config import get_settings
 
 
 def generate_slide_json(prompt: str, style: Dict[str, Any]) -> List[Dict[str, Any]]:
     settings = get_settings()
+    # Import OpenAI lazily so tests can run without the package installed
+    import openai
     openai.api_key = settings.openai_api_key
 
     system_prompt = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prompt_to_ppt"
+version = "0.1.0"
+description = "Generate PowerPoint slides from text prompts"
+dependencies = [
+    "flask",
+    "pydantic",
+    "python-pptx",
+    "openai",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
+
+[tool.setuptools.package-data]
+"" = ["templates/*.html"]
+


### PR DESCRIPTION
## Summary
- make `openai` an optional import for tests
- add a `pyproject.toml` with project metadata for uv
- update README quickstart instructions to use `uv`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*