### PR TITLE
Fix packaging setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,5 @@ dev = [
 ]
 
 [tool.setuptools.package-data]
-"" = ["templates/*.html"]
+app = ["templates/*.html"]
 


### PR DESCRIPTION
## Summary
- fix the `tool.setuptools.package-data` key so editable install works

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `pip install pytest` *(fails: No matching distribution found)*